### PR TITLE
Update base miner code to fix Server.serve error

### DIFF
--- a/template/base/miner.py
+++ b/template/base/miner.py
@@ -105,6 +105,15 @@ class BaseMinerNeuron(BaseNeuron):
         self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor)
 
         # Start  starts the miner's axon, making it active on the network.
+        log_level = "trace" if bt.logging.__trace_on__ else "critical"
+        fast_config = uvicorn.Config(
+            self.axon.app,
+            host="0.0.0.0",
+            port=self.config.axon.port,
+            log_level=log_level,
+            loop="asyncio"
+        )
+        self.axon.fast_server = FastAPIThreadedServer(config=fast_config)
         self.axon.start()
 
         bt.logging.info(f"Miner starting at block: {self.block}")


### PR DESCRIPTION
This PR fixes the following error:
```
 Exception in thread Thread-3 (run):
2|server  | Traceback (most recent call last):
2|server  |   File "/usr/local/lib/python3.10/dist-packages/nest_asyncio.py", line 27, in run
2|server  |     loop = asyncio.get_event_loop()
2|server  |   File "/usr/local/lib/python3.10/dist-packages/nest_asyncio.py", line 45, in _get_event_loop
2|server  |     loop = events.get_event_loop_policy().get_event_loop()
2|server  |   File "/usr/lib/python3.10/asyncio/events.py", line 656, in get_event_loop
2|server  |     raise RuntimeError('There is no current event loop in thread %r.'
2|server  | RuntimeError: There is no current event loop in thread 'Thread-3 (run)'.
2|server  | During handling of the above exception, another exception occurred:
2|server  | Traceback (most recent call last):
2|server  |   File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
2|server  |     self.run()
2|server  |   File "/usr/lib/python3.10/threading.py", line 953, in run
2|server  |     self._target(*self._args, **self._kwargs)
2|server  |   File "/usr/local/lib/python3.10/dist-packages/uvicorn/server.py", line 61, in run
2|server  |     return asyncio.run(self.serve(sockets=sockets))
2|server  |   File "/usr/local/lib/python3.10/dist-packages/nest_asyncio.py", line 31, in run
2|server  |     _patch_loop(loop)
2|server  |   File "/usr/local/lib/python3.10/dist-packages/nest_asyncio.py", line 175, in _patch_loop
2|server  |     raise ValueError('Can\'t patch loop of type %s' % type(loop))
2|server  | ValueError: Can't patch loop of type <class 'uvloop.Loop'>
2|server  | /usr/lib/python3.10/threading.py:1018: RuntimeWarning: coroutine 'Server.serve' was never awaited
2|server  |   self._invoke_excepthook(self)
2|server  | RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

Co-authored-by: @robertalanm